### PR TITLE
Improve type-hint and default for $currentVersion

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -35,12 +35,12 @@ class Updater
     public function __construct() {}
 
     /**
-     * @param int $currentVersion
+     * @param string $currentVersion
      * @param bool $fetchAll
      * @return $this
      * @throws \Exception
      */
-    public function fetchUpdates($currentVersion = 0, $fetchAll = false)
+    public function fetchUpdates($currentVersion = '0', $fetchAll = false)
     {
         if (!$this->filePath) {
             throw new \Exception('$filePath not defined.');


### PR DESCRIPTION
`version_compare` expects string values. `$currentVersion` should be type-hinted as a string.

It's debatable if the default value should be `''` or `'0'`, but I believe for `version_compare()` purposes they're equivalent, and '0' seems more like a realistic version number to me.